### PR TITLE
- Runtime.NetCore: Rolling back to 2.2.0 to insure compatibility with…

### DIFF
--- a/src/BindOpen.Runtime.NetCore/BindOpen.Runtime.NetCore.csproj
+++ b/src/BindOpen.Runtime.NetCore/BindOpen.Runtime.NetCore.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
… .NET Core 2.2.